### PR TITLE
Allow the gem to use Rails 7+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     capitalize_attributes (0.1.1)
-      activemodel (>= 5.0, < 7.0)
+      activemodel (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.2
+   2.3.5

--- a/capitalize_attributes.gemspec
+++ b/capitalize_attributes.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 5.0", "< 7.0"
+  spec.add_dependency "activemodel", ">= 5.0"
   spec.add_development_dependency "rspec", "~> 3.9"
 end

--- a/lib/capitalize_attributes/version.rb
+++ b/lib/capitalize_attributes/version.rb
@@ -1,3 +1,3 @@
 module CapitalizeAttributes
-  VERSION = "0.1.1"
+  VERSION = "0.2"
 end


### PR DESCRIPTION
This gem was initially created to depend on Rails < 7.0. This PR removes that requirement, leaving only the requirement for Rails >= 5.0.